### PR TITLE
fix travis error: Buildtools 24.0.2 requires Java 1.8 or above.  Curr…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ android:
     # if you need to run emulator(s) during your tests
     # - sys-img-armeabi-v7a-android-19
     # - sys-img-x86-android-17
+jdk:
+    - oraclejdk8
 sudo: false
 script: ./gradlew build check


### PR DESCRIPTION
…ent JDK version is 1.7.

I do not know if this is sufficient, but it should fix the first error from travis build we are currently having in your background_improvements branch.
