### PR TITLE
travis: add flag for stacktrace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ android:
 jdk:
     - oraclejdk8
 sudo: false
-script: ./gradlew build check
+script: ./gradlew build check --stacktrace


### PR DESCRIPTION
Let's enable the stacktrace, maybe we get more info on the lint error then.
