### PR TITLE
travis: enable lint report as text on commandline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ android:
 jdk:
     - oraclejdk8
 sudo: false
-script: ./gradlew build check
+script:
+  - sed -i 's,textReport false,textReport true,g' app/build.gradle
+  - ./gradlew build check

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,10 @@ android {
 
     lintOptions {
         lintConfig file("lint.xml")
+        textReport false
+        htmlReport false
+        xmlReport false
+        explainIssues true
     }
 
     buildTypes {


### PR DESCRIPTION
so, but this gives us the text of the failing lint
